### PR TITLE
Fix error on prepare ligand

### DIFF
--- a/test/virtual_screening/vina/spark/run_all_analysis.sh
+++ b/test/virtual_screening/vina/spark/run_all_analysis.sh
@@ -2,23 +2,24 @@
 
 spark_paths=$1
 path_files=$2
+d_memory=$3"g"
 
-$spark_paths --driver-memory 20g $path_files"/"create_file_for_analysis.py
+$spark_paths --driver-memory $d_memory $path_files"/"create_file_for_analysis.py
 
-$spark_paths --driver-memory 20g $path_files"/"prepare_files_for_analysis.py
+$spark_paths --driver-memory $d_memory $path_files"/"prepare_files_for_analysis.py
 
-$spark_paths --driver-memory 20g $path_files"/"ligand_efficiency.py
+$spark_paths --driver-memory $d_memory $path_files"/"ligand_efficiency.py
 
-$spark_paths --driver-memory 20g $path_files"/"buried_areas.py 0.14 24
+$spark_paths --driver-memory $d_memory $path_files"/"buried_areas.py 0.14 24
 
-$spark_paths --driver-memory 20g $path_files"/"buried_area_receptor.py
+$spark_paths --driver-memory $d_memory $path_files"/"buried_area_receptor.py
 
-$spark_paths --driver-memory 20g $path_files"/"buried_area_ligand.py  0.14 24
+$spark_paths --driver-memory $d_memory $path_files"/"buried_area_ligand.py  0.14 24
 
-$spark_paths --driver-memory 20g $path_files"/"hydrogen_bind.py 4.0 30.0
+$spark_paths --driver-memory $d_memory $path_files"/"hydrogen_bind.py 4.0 30.0
 
-$spark_paths --driver-memory 20g $path_files"/"vs_full_data_analysis.py
+$spark_paths --driver-memory $d_memory $path_files"/"vs_full_data_analysis.py
 
-$spark_paths --driver-memory 20g $path_files"/"buried_area_residue_selection.py
+$spark_paths --driver-memory $d_memory $path_files"/"buried_area_residue_selection.py
 
-$spark_paths --driver-memory 20g $path_files"/"hydrogen_bind_residue_selection.py
+$spark_paths --driver-memory $d_memory $path_files"/"hydrogen_bind_residue_selection.py

--- a/virtualscreening/vina/python/vina.py
+++ b/virtualscreening/vina/python/vina.py
@@ -66,7 +66,7 @@ def get_files_mol2(mypath):
 
 def check_for_preparing_ligand(mol2_path, pdbqt_ligand_path, pythonsh, script_ligand4):
 
-	if len(get_files_mol2(mol2_path)) == 0 or len(get_files_pdb(mol2_path)) == 0:
+	if len(get_files_mol2(mol2_path)) == 0 and len(get_files_pdb(mol2_path)) == 0:
 		raise EnvironmentError("Either mol2 or pdb of ligands not found ")
 
 	if not os.path.exists(pdbqt_ligand_path):


### PR DESCRIPTION
The current version of check_for_prepare_ligand method on vina.py script returns true if mol2 ligand folder or pdb ligand folder are empty when usually one of them can be empty, this PR fix the logical error.